### PR TITLE
.NET 6.0 upgrade

### DIFF
--- a/Contentful.ModelsCreator.Cli/Contentful.ModelsCreator.Cli.csproj
+++ b/Contentful.ModelsCreator.Cli/Contentful.ModelsCreator.Cli.csproj
@@ -4,22 +4,22 @@
     <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
-    <Version>0.9.1</Version>
+    <Version>0.9.2</Version>
     <Company>Contentful GmbH</Company>
     <Authors>Contentful</Authors>
     <PackageId>contentful.modelscreator.cli</PackageId>
     <PackageTags>contentful;CMS;cli</PackageTags>
     <Copyright>Contentful GmbH.</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>0.9.1.0</AssemblyVersion>
-    <FileVersion>0.9.1.0</FileVersion>
+    <AssemblyVersion>0.9.2.0</AssemblyVersion>
+    <FileVersion>0.9.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="contentful.csharp" Version="3.6.1" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
+    <PackageReference Include="contentful.csharp" Version="7.0.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A dotnet CLI to automatically create strongly typed c-sharp models. This CLI tool is used internally by the Contentful Visual Studio plugin and the Contentful Visual Studio Code plugin.
 
 ## Prerequisites
-The CLI tool uses the "global tools" feature of .NET Core 2.1 and requires the .NET Core 2.1 SDK to be installed. https://www.microsoft.com/net/download/dotnet-core/2.1
+The CLI tool uses the "[global tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools)" feature of .NET Core 6.0 and requires the .NET Core 6.0 SDK to be installed. https://www.microsoft.com/net/download/dotnet-core/6.0
 
 ## Installation
 Run `dotnet tool install -g contentful.modelscreator.cli` from your command line.


### PR DESCRIPTION
.NET core 2.1 has now reached end of life, this is to ugprade to the latest LTS version (.NET 6.0). I have tested this using `dotnet run ...` on my space and worked successfully, you will need to push this to nuget as part of merging this change in.

Thanks.